### PR TITLE
[Issue4] Fixes issue 4.

### DIFF
--- a/Classes/AFKPageFlipper.m
+++ b/Classes/AFKPageFlipper.m
@@ -180,6 +180,10 @@
 
 
 - (void) setFlipProgress:(float) progress setDelegate:(BOOL) setDelegate animate:(BOOL) animate {
+    if (animate) {
+        animating = YES;
+    }
+    
 	float newAngle = startFlipAngle + progress * (endFlipAngle - startFlipAngle);
 	
 	float duration = animate ? 0.5 * fabs((newAngle - currentAngle) / (endFlipAngle - startFlipAngle)) : 0;
@@ -355,6 +359,10 @@
 
 
 - (void) panned:(UIPanGestureRecognizer *) recognizer {
+    if (animating) {
+        return;
+    }
+    
 	static BOOL hasFailed;
 	static BOOL initialized;
 	
@@ -406,7 +414,6 @@
 				
 				hasFailed = NO;
 				initialized = TRUE;
-				animating = YES;
 				setNewViewOnCompletion = NO;
 				
 				[self initFlip];


### PR DESCRIPTION
When the pan gesture finishes, we animate and delegate to the final view state of the "flip". But prior to this commit, we don't set the "animating" guard to true that prevents the user from quickly starting other erroneous animations. By setting this guard up properly, we can prevent Issue4 from occurring.
