### PR TITLE
[Issue6] Fixes issue 6

### DIFF
--- a/Classes/AFKPageFlipper.m
+++ b/Classes/AFKPageFlipper.m
@@ -313,6 +313,7 @@
 	
 	dataSource = [value retain];
 	numberOfPages = [dataSource numberOfPagesForPageFlipper:self];
+    currentPage = 0;
 	self.currentPage = 1;
 }
 


### PR DESCRIPTION
[Issue6] By setting currentPage to 0 before setting self.currentPage to 1, we force the setCurrentPage method to properly redraw the page, rather than just returning.
