### PR TITLE
[Issue8] Make sure view is opaque before grabbing a UIImage

### DIFF
--- a/Classes/AFKPageFlipper.m
+++ b/Classes/AFKPageFlipper.m
@@ -24,12 +24,13 @@
 
 
 - (UIImage *) imageByRenderingView {
-	
-	UIGraphicsBeginImageContext(self.bounds.size);
+    CGFloat oldAlpha = self.alpha;
+    self.alpha = 1;
+    UIGraphicsBeginImageContext(self.bounds.size);
 	[self.layer renderInContext:UIGraphicsGetCurrentContext()];
 	UIImage *resultingImage = UIGraphicsGetImageFromCurrentImageContext();
 	UIGraphicsEndImageContext();
-	
+    self.alpha = oldAlpha;
 	return resultingImage;
 }
 


### PR DESCRIPTION
When you are reusing views in the PageFlipper, in some cases their alpha
 will be 0 when we grab a screenshot of them. This makes for some errone
ous flip states. By setting the alpha to 1, and then restoring it to wha
tever it was prior to the screenshot, we can ensure we get a proper scre
enshot of the view.
