### PR TITLE
Fix for swiping very quickly during the flip animation

### DIFF
--- a/Classes/AFKPageFlipper.h
+++ b/Classes/AFKPageFlipper.h
@@ -21,6 +21,15 @@
 @end
 
 
+@protocol AFKPageFlipperDelegate <NSObject>
+
+@optional
+- (void)pageFlipper:(AFKPageFlipper *)pageFlipper
+	  didFlipToPage:(NSInteger)page;
+
+@end
+
+
 typedef enum {
 	AFKPageFlipperDirectionLeft,
 	AFKPageFlipperDirectionRight,
@@ -51,12 +60,14 @@ typedef enum {
 }
 
 @property (nonatomic,retain) NSObject <AFKPageFlipperDataSource> *dataSource;
+@property (nonatomic, assign) id <AFKPageFlipperDelegate> delegate;
 @property (nonatomic,assign) NSInteger currentPage;
 
 @property (nonatomic, retain) UITapGestureRecognizer *tapRecognizer;
 @property (nonatomic, retain) UIPanGestureRecognizer *panRecognizer;
 
 @property (nonatomic,assign) BOOL disabled;
+
 
 - (void) setCurrentPage:(NSInteger) value animated:(BOOL) animated;
 

--- a/Classes/AFKPageFlipper.m
+++ b/Classes/AFKPageFlipper.m
@@ -180,6 +180,7 @@
 	}
 
 	self.currentView.alpha = 1;
+	[self setUserInteractionEnabled:YES];
 }
 
 
@@ -199,6 +200,7 @@
 	endTransform = CATransform3DRotate(endTransform, newAngle, 0.0, 1.0, 0.0);	
 	
 	[flipAnimationLayer removeAllAnimations];
+	[self setUserInteractionEnabled:NO];
 							
 	[CATransaction begin];
 	[CATransaction setAnimationDuration:duration];

--- a/Classes/AFKPageFlipper.m
+++ b/Classes/AFKPageFlipper.m
@@ -53,6 +53,7 @@
 
 @synthesize tapRecognizer = _tapRecognizer;
 @synthesize panRecognizer = _panRecognizer;
+@synthesize delegate;
 
 
 #pragma mark -
@@ -211,6 +212,16 @@
 	
 	if (setDelegate) {
 		[self performSelector:@selector(cleanupFlip) withObject:Nil afterDelay:duration];
+	}
+	
+	if (progress == 1.0f) {
+		if ([self delegate] != nil) {
+			if ([[self delegate] respondsToSelector:@selector(pageFlipper:didFlipToPage:)]) {
+				[[self delegate] pageFlipper:self
+							   didFlipToPage:[self currentPage]];
+			}
+		}
+
 	}
 }
 


### PR DESCRIPTION
Disable user interaction during the animation to avoid bugs when flipping very quickly. Solves issue #14.

Thanks to @markph0204 for making this change in his fork:

https://github.com/markph0204/AFKPageFlipper/commit/04f7071ffe74832e1fc6fb393f09071186506884
